### PR TITLE
feat(configs): enhance install script and add zsh aliases

### DIFF
--- a/configs/install.sh
+++ b/configs/install.sh
@@ -1,19 +1,35 @@
 #!/bin/bash
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SSH_DIR="${HOME}/.ssh"
+GH_CONFIG_DIR="${HOME}/.config/gh"
 
 # create symbolic links
 create_symlink() {
-  ln -sf "${DIR}/$1" "${HOME}/$2"
+  if [ -e "${HOME}/$2" ]; then
+    echo "-> Skipping $2, already exists."
+  else
+    ln -sf "${DIR}/$1" "${HOME}/$2"
+    echo "-> Symlink created for $1"
+  fi
 }
 
 # configure ssh
 configure_ssh() {
-  ssh-keygen -t ed25519 -C "phat@onroads.xyz" -f "${HOME}/.ssh/id_ed25519" -P ""
-  ssh-keygen -t ed25519 -C "phatttpham9@gmail.com" -f "${HOME}/.ssh/id_ed25519_secondary" -P ""
+  mkdir -p "${SSH_DIR}"
+  if [ ! -f "${SSH_DIR}/id_ed25519" ]; then
+    ssh-keygen -t ed25519 -C "phat@onroads.xyz" -f "${SSH_DIR}/id_ed25519" -P ""
+  else
+    echo "-> SSH key id_ed25519 already exists."
+  fi
+  if [ ! -f "${SSH_DIR}/id_ed25519_secondary" ]; then
+    ssh-keygen -t ed25519 -C "phatttpham9@gmail.com" -f "${SSH_DIR}/id_ed25519_secondary" -P ""
+  else
+    echo "-> SSH key id_ed25519_secondary already exists."
+  fi
   create_symlink "ssh/config" ".ssh/config"
   create_symlink "ssh/config_secondary" ".ssh/config_secondary"
-  echo "-> ssh key generated & configured!"
+  echo "-> SSH keys generated & configured!"
   echo "-> Attention! Don't forget to copy the public key & add it to remote hosts such as github.com & gitlab.com."
 }
 
@@ -22,30 +38,23 @@ configure_git() {
   create_symlink "git/gitconfig" ".gitconfig"
   create_symlink "git/gitconfig_secondary" ".gitconfig_secondary"
   create_symlink "git/gitignore_global" ".gitignore_global"
-  echo "-> git configured!"
+  echo "-> Git configured!"
 }
 
 # configure gh
 configure_gh() {
-  if [ ! -d "${HOME}/.config/gh" ]; then
-    mkdir -p "${HOME}/.config/gh"
-  fi
+  mkdir -p "${GH_CONFIG_DIR}"
   create_symlink "gh/config.yml" ".config/gh/config.yml"
   create_symlink "gh/hosts.yml" ".config/gh/hosts.yml"
-  echo "-> gh configured!"
+  echo "-> GitHub CLI configured!"
 }
 
 # configure zsh
 configure_zsh() {
   create_symlink "zsh/zshrc" ".zshrc"
-  echo "-> zsh configured!"
+  create_symlink "zsh/zsh_aliases" ".zsh_aliases"
+  echo "-> Zsh configured!"
 }
-
-# call the configuration functions
-configure_ssh
-configure_git
-configure_gh
-configure_zsh
 
 # install gh extensions
 install_gh_extensions() {
@@ -55,5 +64,9 @@ install_gh_extensions() {
   echo "-> gh extensions installed!"
 }
 
-# call the extension installation functions
+# Main script execution
+configure_ssh
+configure_git
+configure_gh
+configure_zsh
 install_gh_extensions

--- a/configs/zsh/zsh_aliases
+++ b/configs/zsh/zsh_aliases
@@ -1,0 +1,17 @@
+## ssh
+ssha() { eval $(ssh-agent -s); ssh-add "$@"; }
+alias ssht="ssh -T"
+alias sshtgh="ssh -T git@github.com"
+alias sshtgl="ssh -T git@gitlab.com"
+
+## python
+alias py="python3"
+alias python="python3"
+alias pip="pip3"
+
+## docker
+alias docker=podman
+
+## other
+alias clean="rm ~/.zsh_history"
+alias myip="curl https://ipecho.net/plain; echo"

--- a/configs/zsh/zshrc
+++ b/configs/zsh/zshrc
@@ -19,22 +19,7 @@ export ZSH="$HOME/.oh-my-zsh"
 plugins=(git gh fnm npm podman kind kubectl terraform aws direnv)
 source $ZSH/oh-my-zsh.sh
 
-# aliases
-
-## ssh
-ssha() { eval $(ssh-agent -s); ssh-add "$@"; }
-alias ssht="ssh -T"
-alias sshtgh="ssh -T git@github.com"
-alias sshtgl="ssh -T git@gitlab.com"
-
-## python
-alias py="python3"
-alias python="python3"
-alias pip="pip3"
-
-## docker
-alias docker=podman
-
-## other
-alias clean="rm ~/.zsh_history"
-alias myip="curl https://ipecho.net/plain; echo"
+# source zsh aliases
+if [ -f "${HOME}/.zsh_aliases" ]; then
+  source "${HOME}/.zsh_aliases"
+fi


### PR DESCRIPTION
This pull request includes several changes to the `configs/install.sh` script and related configuration files to improve the setup process and organization. The most important changes include adding checks for existing files before creating symlinks or generating SSH keys, organizing aliases into a separate file, and updating echo messages for clarity.

Improvements to setup script:

* [`configs/install.sh`](diffhunk://#diff-55a695c7d0db7ec327271b9178622860103e244f05e6671cd699fd54876474bcR4-R32): Added checks to avoid overwriting existing files when creating symlinks and generating SSH keys. Updated echo messages for better clarity. [[1]](diffhunk://#diff-55a695c7d0db7ec327271b9178622860103e244f05e6671cd699fd54876474bcR4-R32) [[2]](diffhunk://#diff-55a695c7d0db7ec327271b9178622860103e244f05e6671cd699fd54876474bcL25-L49) [[3]](diffhunk://#diff-55a695c7d0db7ec327271b9178622860103e244f05e6671cd699fd54876474bcL58-R71)

Organization of aliases:

* [`configs/zsh/zsh_aliases`](diffhunk://#diff-8906ff9a0a831ba4b141fc323be92a14dbfee9e035216fb5d85c136aabd5f428R1-R17): Moved SSH, Python, Docker, and other aliases to a separate file for better organization.
* [`configs/zsh/zshrc`](diffhunk://#diff-657278026881b9dbca3f79aa4c7c7ca8a3e024e2585d7348158e41ae4099804eL22-R25): Updated to source the new `zsh_aliases` file if it exists, removing inline alias definitions.